### PR TITLE
Implement generalization experiments

### DIFF
--- a/hydra_conf/config.yaml
+++ b/hydra_conf/config.yaml
@@ -3,6 +3,7 @@ defaults:
 
 results_dir: ???  # Mandatory, no default value
 num_train_iter: 30000
+val_freq: 30000
 seed: 0
 eval_seed: 0
 eval_protocol: "train"

--- a/hydra_conf/config.yaml
+++ b/hydra_conf/config.yaml
@@ -1,5 +1,5 @@
 defaults:
-  - env: SGD/MNIST
+  - env: LayerwiseSGD/MNIST
 
 results_dir: ???  # Mandatory, no default value
 num_train_iter: 30000

--- a/hydra_conf/env/LayerwiseSGD.yaml
+++ b/hydra_conf/env/LayerwiseSGD.yaml
@@ -5,4 +5,5 @@ state_version: basic
 num_epochs: 20
 num_runs: 20
 epoch_mode: false
-instance_mode: random_seed
+instance_mode: instance_set
+instance_set_path: "../instance_sets/sgd/sgd_mnist_train.csv"

--- a/hydra_conf/env/LayerwiseSGD.yaml
+++ b/hydra_conf/env/LayerwiseSGD.yaml
@@ -5,5 +5,4 @@ state_version: basic
 num_epochs: 20
 num_runs: 20
 epoch_mode: false
-instance_mode: instance_set
-instance_set_path: "../instance_sets/sgd/sgd_mnist_train.csv"
+instance_mode: random_seed

--- a/hydra_conf/env/LayerwiseSGD/CIFAR10_gen.yaml
+++ b/hydra_conf/env/LayerwiseSGD/CIFAR10_gen.yaml
@@ -1,0 +1,21 @@
+# Inherit common LayerwiseSGD settings and override specific fields
+defaults:
+  - /env/LayerwiseSGD@_here_
+
+dataset_name: CIFAR10
+num_epochs: 50
+instance_mode: instance_set
+instance_set_path: "../instance_sets/sgd/sgd_cifar_test.csv"
+layer_specification:
+  - ["CONV2D", {"in_channels": 3, "out_channels": 32, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["CONV2D", {"in_channels": 32, "out_channels": 64, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["MAXPOOL2D", {"kernel_size": 2}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["FLATTEN", {"start_dim": 1}]
+  - ["LINEAR", {"in_features": 12544, "out_features": 128}]
+  - ["RELU", {}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["LINEAR", {"in_features": 128, "out_features": 10}]
+  - ["LOGSOFTMAX", {"dim": 1}]

--- a/hydra_conf/env/LayerwiseSGD/FashionMNIST_gen.yaml
+++ b/hydra_conf/env/LayerwiseSGD/FashionMNIST_gen.yaml
@@ -1,0 +1,20 @@
+# Inherit common LayerwiseSGD settings and override specific fields
+defaults:
+  - /env/LayerwiseSGD@_here_
+
+dataset_name: FashionMNIST
+instance_mode: instance_set
+instance_set_path: "../instance_sets/sgd/sgd_fmnist_test.csv"
+layer_specification:
+  - ["CONV2D", {"in_channels": 1, "out_channels": 32, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["CONV2D", {"in_channels": 32, "out_channels": 64, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["MAXPOOL2D", {"kernel_size": 2}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["FLATTEN", {"start_dim": 1}]
+  - ["LINEAR", {"in_features": 9216, "out_features": 128}]
+  - ["RELU", {}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["LINEAR", {"in_features": 128, "out_features": 10}]
+  - ["LOGSOFTMAX", {"dim": 1}]

--- a/hydra_conf/env/LayerwiseSGD/MNIST_gen.yaml
+++ b/hydra_conf/env/LayerwiseSGD/MNIST_gen.yaml
@@ -1,0 +1,20 @@
+# Inherit common LayerwiseSGD settings and override specific fields
+defaults:
+  - /env/LayerwiseSGD@_here_
+
+dataset_name: MNIST
+instance_mode: instance_set
+instance_set_path: "../instance_sets/sgd/sgd_mnist_test.csv"
+layer_specification:
+  - ["CONV2D", {"in_channels": 1, "out_channels": 32, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["CONV2D", {"in_channels": 32, "out_channels": 64, "kernel_size": 3}]
+  - ["RELU", {}]
+  - ["MAXPOOL2D", {"kernel_size": 2}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["FLATTEN", {"start_dim": 1}]
+  - ["LINEAR", {"in_features": 9216, "out_features": 128}]
+  - ["RELU", {}]
+  - ["DROPOUT", {"p": 0.25}]
+  - ["LINEAR", {"in_features": 128, "out_features": 10}]
+  - ["LOGSOFTMAX", {"dim": 1}]

--- a/main.py
+++ b/main.py
@@ -23,8 +23,6 @@ if TYPE_CHECKING:
 
 
 def generate_data(cfg: HydraConfig, env_config: dict, seed: int):
-    num_runs = env_config["num_runs"]
-
     GeneratorClass = LayerwiseDataGenerator if cfg.env.type == "LayerwiseSGD" else DataGenerator
 
     if cfg.combination == "single":
@@ -37,7 +35,6 @@ def generate_data(cfg: HydraConfig, env_config: dict, seed: int):
             teacher_config=teacher_config,
             env_config=env_config,
             result_dir=cfg.results_dir,
-            num_runs=num_runs,
             checkpoint=0,
             seed=seed,
             verbose=False,
@@ -54,7 +51,6 @@ def generate_data(cfg: HydraConfig, env_config: dict, seed: int):
                     teacher_config=teacher_config,
                     env_config=env_config,
                     result_dir=cfg.results_dir,
-                    num_runs=num_runs,
                     checkpoint=0,
                     seed=seed,
                     verbose=False,
@@ -83,7 +79,6 @@ def generate_data(cfg: HydraConfig, env_config: dict, seed: int):
                     env_config=env_config,
                     result_dir=cfg.results_dir,
                     check_if_exists=False,
-                    num_runs=num_runs,
                     checkpoint=0,
                     seed=seed,
                     verbose=False,

--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def eval_agent(cfg: HydraConfig, env_config: dict, seed: int) -> None:
     agent_path = data_dir / "results" / cfg.agent_type / str(seed) / str(cfg.num_train_iter)
     actor = load_agent(cfg.agent_type, agent_path).actor
 
-    EvaluatorClass = LayerwiseEvaluator if cfg.env.type == "LayerwiseSGD" else Evaluator
+    EvaluatorClass = LayerwiseEvaluator if cfg.env_type == "LayerwiseSGD" else Evaluator
     evaluator = EvaluatorClass(data_dir, cfg.eval_protocol, env_config["num_runs"], cfg.eval_seed)
 
     eval_data = evaluator.evaluate(actor)

--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def eval_agent(cfg: HydraConfig, env_config: dict, seed: int) -> None:
     agent_path = data_dir / "results" / cfg.agent_type / str(seed) / str(cfg.num_train_iter)
     actor = load_agent(cfg.agent_type, agent_path).actor
 
-    EvaluatorClass = LayerwiseEvaluator if cfg.env_type == "LayerwiseSGD" else Evaluator
+    EvaluatorClass = LayerwiseEvaluator if cfg.env.type == "LayerwiseSGD" else Evaluator
     evaluator = EvaluatorClass(data_dir, cfg.eval_protocol, env_config["num_runs"], cfg.eval_seed)
 
     eval_data = evaluator.evaluate(actor)

--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ def train_model(cfg: HydraConfig, env_config: dict, seed: int):
         wandb_group=cfg.wandb_group,
         seed=seed,
     )
-    _, inc_value = trainer.train(cfg.num_train_iter, cfg.num_train_iter)
+    _, inc_value = trainer.train(cfg.num_train_iter, cfg.val_freq)
     print(inc_value)
 
 def eval_agent(cfg: HydraConfig, env_config: dict, train_seed: int) -> None:

--- a/scripts/LayerwiseSGD/train_single.sh
+++ b/scripts/LayerwiseSGD/train_single.sh
@@ -20,7 +20,7 @@ SEED=${1:-0}
 AGENT=${2:-td3_bc}
 
 ID=0
-NUM_TRAIN_ITER=60000
+NUM_TRAIN_ITER=30000
 RESULTS_DIR="LayerwiseSGD_data/wandb"
 
 # Print some information about the job to STDOUT

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -47,6 +47,7 @@ class Evaluator:
                 f"Evaluation unsupported for environment: {type(self._env)}",
             )
 
+        self._env.seed(env_config["seed"])
         set_seeds(env_config["seed"])
 
     def _run_batches(self, actor: ActorType, run_idx: int) -> None:

--- a/src/evaluator.py
+++ b/src/evaluator.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import TYPE_CHECKING
 
-import torch
 from DACBench.dacbench.envs import LayerwiseSGDEnv, SGDEnv, ToySGD2DEnv
 
 from src.experiment_data import (
@@ -16,52 +13,33 @@ from src.experiment_data import (
 from src.utils import ActorType, get_environment, set_seeds
 
 if TYPE_CHECKING:
-    import numpy as np
     import pandas as pd
 
 
 class Evaluator:
     def __init__(
         self,
-        data_dir: Path,
-        eval_protocol: str,
-        n_runs: int,
-        seed: int,
+        env_config: dict,
     ) -> None:
-        self._starting_points: np.ndarray | None
-
-        with (data_dir / "run_info.json").open(mode="rb") as f:
-            run_info = json.load(f)
-        self._env = get_environment(run_info["environment"])
-
-        if eval_protocol == "train":
-            self._starting_points = run_info["starting_points"]
-            eval_seed = run_info["seed"]
-        elif eval_protocol == "interpolation":
-            self._starting_points = None
-            eval_seed = seed
+        self._env = get_environment(env_config)
 
         self._exp_data: ExperimentData
         if isinstance(self._env, ToySGD2DEnv):
             self._exp_data = ToySGDExperimentData()
-            self._n_runs = (
-                n_runs
-                if n_runs is not None
-                else len(run_info["starting_points"])
-            )
-            self._n_batches = run_info["environment"]["num_batches"]
+            self._num_runs = env_config["num_runs"]
+            self._num_batches = env_config["num_batches"]
         elif isinstance(self._env, SGDEnv):
             self._exp_data = SGDExperimentData()
             self._env.reset()
-            self._n_runs = n_runs
-            self._n_batches = run_info["environment"]["num_epochs"] * len(
+            self._num_runs = env_config["num_runs"]
+            self._num_batches = env_config["num_epochs"] * len(
                 self._env.train_loader,
             )
         elif isinstance(self._env, LayerwiseSGDEnv):
             self._exp_data = LayerwiseSGDExperimentData()
             self._env.reset()
-            self._n_runs = n_runs
-            self._n_batches = run_info["environment"]["num_epochs"] * len(
+            self._num_runs = env_config["num_runs"]
+            self._num_batches = env_config["num_epochs"] * len(
                 self._env.train_loader,
             )
         else:
@@ -69,8 +47,7 @@ class Evaluator:
                 f"Evaluation unsupported for environment: {type(self._env)}",
             )
 
-        self._env.seed(eval_seed)
-        set_seeds(eval_seed)
+        set_seeds(env_config["seed"])
 
     def _run_batches(self, actor: ActorType, run_idx: int) -> None:
         """Evaluate specific run for a given number of batches.
@@ -85,7 +62,7 @@ class Evaluator:
         # [state] workaround due to layerwise/Liskov principle
         self._exp_data.init_data(run_idx, [state], self._env)
 
-        for batch_idx in range(1, self._n_batches + 1):
+        for batch_idx in range(1, self._num_batches + 1):
             action = actor.act(state)
             next_state, reward, done, _, _ = self._env.step(action.item())
             state = next_state
@@ -111,21 +88,9 @@ class Evaluator:
         """Evaluates n starting points."""
         actor.eval()
 
-        if self._starting_points is not None and len(self._starting_points) > 0:
-            for run_id, starting_point in enumerate(
-                self._starting_points[: self._n_runs],
-            ):
-                self._env.reset(
-                    seed=None,
-                    options={
-                        "starting_point": torch.tensor(starting_point),
-                    },
-                )
-                self._run_batches(actor, run_id)
-        else:
-            for run_id in range(self._n_runs):
-                self._env.reset()
-                self._run_batches(actor, run_id)
+        for run_id in range(self._num_runs):
+            self._env.reset()
+            self._run_batches(actor, run_id)
 
         actor.train()
         return self._exp_data.concatenate_data()
@@ -144,14 +109,16 @@ class LayerwiseEvaluator(Evaluator):
 
         self._exp_data.init_data(run_idx, states, self._env)
 
-        for batch_idx in range(1, self._n_batches + 1):
+        for batch_idx in range(1, self._num_batches + 1):
             actions = []
             for state in states:
                 action = actor.act(state)
                 actions.append(action.item())
             next_states, reward, done, _, _ = self._env.step(actions)
 
-            for layer_idx, (state, action) in enumerate(zip(states, actions)):
+            for layer_idx, (state, action) in enumerate(
+                zip(states, actions, strict=True),
+            ):
                 self._exp_data.add(
                     {
                         "state": state.cpu().numpy(),

--- a/src/utils/hydra_config.py
+++ b/src/utils/hydra_config.py
@@ -15,6 +15,7 @@ class Config(DictConfig):
     # Optional fields with default values
     env: dict = MISSING
     num_train_iter: int = 30000
+    val_freq: int = 30000
     seed: int = 0
     eval_seed: int = 0
     eval_protocol: str = "train"

--- a/src/utils/hydra_config.py
+++ b/src/utils/hydra_config.py
@@ -21,6 +21,9 @@ class Config(DictConfig):
     teacher: str = "step_decay"
     wandb_group: str = "DACORL"
     instance_mode: str | None = None  # None if not provided
+    instance_set_path: str | None = (
+        None  # Only needed if instance_mode = "instance_set"
+    )
     id: int = 0
     agent_type: Literal[
         "bc",


### PR DESCRIPTION
>Please only merge after merging DACBench PR + updating DACBench ref in this repo!

Currently implemented by specifying a new generalization instance set.

Generally reworked run_info and everything related to it so that it now only stores information about the teacher and the environment. Due to our proper seeding, I also removed the different evaluation protocols. The field `eval_protocol` in the config is currently only used to adjust the file name of the evaluation data when using `mode=eval`. Maybe we can think of a way automating this, but I did not find a satisfying solution yet :D

I also added the option to specify the validation frequency during training. As our validation scheme during training is generally only the formerly known `train` evaluation protocol (same starting points/run seeds), we might not be interested in this in latter stages of our experiments, i.e., we only want to train the agent and then in the next step run evaluation using a different evaluation protocol (using `mode=eval` in the hydra config). This could then easily be done using `val_freq > num_train_iter` and then starting evaluation separately.